### PR TITLE
Fix historical_indexer.dart

### DIFF
--- a/bin/historical_indexer.dart
+++ b/bin/historical_indexer.dart
@@ -168,6 +168,7 @@ Future<void> processRepo(String did) async {
               parts[1],
               block.cast<String, dynamic>(),
               surreal: surreal,
+              doRethrow: true,
             );
           }
         }


### PR DESCRIPTION
`processGraphOperation` requires passing a value for `doRethrow`